### PR TITLE
Remove method_missing attribute search

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## 0.1.2
 
-- Moved config option definition from `#method_missing` to `#define_singleton_method`
+- Move config struct option definition from `#method_missing` to `#define_singleton_method`
 
 ## 0.1.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.1.2
+
+- Moved config option definition from `#method_missing` to `#define_singleton_method`
+
 ## 0.1.1
 
 - Remove Rails dependency.

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    config_default (0.1.1)
+    config_default (0.1.2)
       activesupport (~> 6)
 
 GEM

--- a/lib/config_default/struct.rb
+++ b/lib/config_default/struct.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class ConfigDefault::Struct
-  RESERVED_METHODS = %w[method_missing respond_to_missing? to_hash].freeze
+  RESERVED_METHODS = %i[method_missing respond_to_missing? to_hash].freeze
 
   def initialize(attributes = {}, recursive: false, allow_nil: false)
     @attributes = ActiveSupport::HashWithIndifferentAccess.new(attributes)
@@ -16,7 +16,7 @@ class ConfigDefault::Struct
     end
 
     @attributes.each do |key, value|
-      next if RESERVED_METHODS.include?(key.to_s)
+      next if RESERVED_METHODS.include?(key.to_sym)
       define_singleton_method(key) { value }
     end
 

--- a/lib/config_default/struct.rb
+++ b/lib/config_default/struct.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 class ConfigDefault::Struct
+  RESERVED_METHODS = %w[method_missing respond_to_missing? to_hash].freeze
+
   def initialize(attributes = {}, recursive: false, allow_nil: false)
     @attributes = ActiveSupport::HashWithIndifferentAccess.new(attributes)
     @allow_nil = allow_nil
@@ -13,6 +15,11 @@ class ConfigDefault::Struct
       end
     end
 
+    @attributes.each do |key, value|
+      next if RESERVED_METHODS.include?(key.to_s)
+      define_singleton_method(key) { value }
+    end
+
     @attributes.freeze
   end
 
@@ -21,7 +28,6 @@ class ConfigDefault::Struct
   end
 
   def method_missing(method, *_args)
-    return @attributes[method] if @attributes.key?(method)
     raise StandardError.new("There is no option :#{method} in configuration.") unless @allow_nil
   end
 

--- a/lib/config_default/version.rb
+++ b/lib/config_default/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module ConfigDefault
-  VERSION = "0.1.1"
+  VERSION = "0.1.2"
 end


### PR DESCRIPTION
- According to https://franck.verrot.fr/blog/2015/07/12/benchmarking-ruby-method-missing-and-define-method it's better to remove value search via `method_missing`
- Version bump