### PR TITLE
Better rails monkey path apply. Rails extension classes without namespace.

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    config_default (0.2.0)
+    config_default (0.2.1)
       activesupport (~> 6)
 
 GEM

--- a/README.md
+++ b/README.md
@@ -33,6 +33,14 @@ ConfigDefault.configure do |config|
 end
 ```
 
+If you want to implement Rails monkey patches for `Rails.application.config_for` and ability to
+separate `database.yml` file you need to apply `#init_rails_monkey_patch!` method in your
+`application.yml` file before application initialization.
+
+```ruby
+  ConfigDefault.init_rails_monkey_patch!
+```
+
 ## Usage
 
 ### Default behaviour

--- a/lib/config_default.rb
+++ b/lib/config_default.rb
@@ -4,8 +4,8 @@ require "active_support/core_ext/hash"
 
 require "config_default/version"
 require "config_default/config"
-require "config_default/struct"
 require "config_default/init"
+require "config_default/struct"
 require "config_default/rails_application_extension"
 require "config_default/rails_application_configuration_extension"
 

--- a/lib/config_default.rb
+++ b/lib/config_default.rb
@@ -5,7 +5,9 @@ require "active_support/core_ext/hash"
 require "config_default/version"
 require "config_default/config"
 require "config_default/struct"
-require "config_default/rails_monkey_patch"
+require "config_default/init"
+require "config_default/rails_application_extension"
+require "config_default/rails_application_configuration_extension"
 
 module ConfigDefault
   extend self
@@ -16,6 +18,10 @@ module ConfigDefault
 
   def configure
     yield(config) if block_given?
+  end
+
+  def init_rails_monkey_patch!
+    ConfigDefault::Init.init_rails_monkey_patch!
   end
 
   def load(name, key: Rails.env, symbolize_keys: false, deep_symbolize_keys: false)
@@ -49,5 +55,3 @@ module ConfigDefault
     )
   end
 end
-
-ConfigDefault::RailsMonkeyPatch.call

--- a/lib/config_default/init.rb
+++ b/lib/config_default/init.rb
@@ -1,14 +1,14 @@
 # frozen_string_literal: true
 
-module ConfigDefault::RailsMonkeyPatch
+module ConfigDefault::Init
   extend self
 
-  def call
+  def init_rails_monkey_patch!
     return unless Object.const_defined?("Rails")
     return unless Object.const_defined?("Rails::Application")
     return unless Object.const_defined?("Rails::Application::Configuration")
 
-    require "config_default/rails/application_extension"
-    require "config_default/rails/application/configuration_extension"
+    Rails::Application.prepend(ConfigDefault::RailsApplicationExtension)
+    Rails::Application::Configuration.prepend(ConfigDefault::RailsApplicationConfigurationExtension)
   end
 end

--- a/lib/config_default/rails_application_configuration_extension.rb
+++ b/lib/config_default/rails_application_configuration_extension.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-module Rails::Application::ConfigurationExtension
+module ConfigDefault::RailsApplicationConfigurationExtension
   def load_database_yaml
     ConfigDefault.load(:database, key: nil)
   end
@@ -9,5 +9,3 @@ module Rails::Application::ConfigurationExtension
     load_database_yaml
   end
 end
-
-Rails::Application::Configuration.prepend(Rails::Application::ConfigurationExtension)

--- a/lib/config_default/rails_application_extension.rb
+++ b/lib/config_default/rails_application_extension.rb
@@ -6,5 +6,3 @@ module ConfigDefault::RailsApplicationExtension
     ActiveSupport::OrderedOptions.new.merge(data)
   end
 end
-
-

--- a/lib/config_default/rails_application_extension.rb
+++ b/lib/config_default/rails_application_extension.rb
@@ -1,10 +1,10 @@
 # frozen_string_literal: true
 
-module Rails::ApplicationExtension
+module ConfigDefault::RailsApplicationExtension
   def config_for(name, env: Rails.env)
     data = ConfigDefault.load(name, key: env, deep_symbolize_keys: true)
     ActiveSupport::OrderedOptions.new.merge(data)
   end
 end
 
-Rails::Application.prepend(Rails::ApplicationExtension)
+

--- a/lib/config_default/version.rb
+++ b/lib/config_default/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module ConfigDefault
-  VERSION = "0.2.0"
+  VERSION = "0.2.1"
 end

--- a/spec/config_default_spec.rb
+++ b/spec/config_default_spec.rb
@@ -72,7 +72,9 @@ describe ConfigDefault do
   end
 end
 
-describe Rails::Application do
+ConfigDefault.init_rails_monkey_patch!
+
+describe ConfigDefault::RailsApplicationExtension do
   describe "#config_for" do
     it "load configuration in rails style" do
       make_rails_app
@@ -85,7 +87,7 @@ describe Rails::Application do
   end
 end
 
-describe Rails::Application::Configuration do
+describe ConfigDefault::RailsApplicationConfigurationExtension do
   describe "#load_database_yaml" do
     it "load database configuration in rails style" do
       make_rails_app


### PR DESCRIPTION
- Remove Rails namespace for extension modules.
- Move monkey patch apply to extend module and init method.
- Docs `#init_rails_monkey_patch!`
- Specs