### PR TITLE
Moving to ArgumentError for better semantics.

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    config_default (0.2.2)
+    config_default (0.2.3)
       activesupport (>= 6)
 
 GEM
@@ -212,6 +212,7 @@ GEM
 
 PLATFORMS
   x86_64-darwin-20
+  x86_64-darwin-21
   x86_64-linux
 
 DEPENDENCIES

--- a/lib/config_default/struct.rb
+++ b/lib/config_default/struct.rb
@@ -20,7 +20,7 @@ class ConfigDefault::Struct
 
   def method_missing(method, *_args)
     return if @allow_nil
-    raise StandardError.new("There is no option :#{method} in configuration.")
+    raise ArgumentError.new("There is no option :#{method} in configuration.")
   end
 
   def respond_to_missing?(*_args)

--- a/lib/config_default/version.rb
+++ b/lib/config_default/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module ConfigDefault
-  VERSION = "0.2.2"
+  VERSION = "0.2.3"
 end

--- a/spec/config_default_spec.rb
+++ b/spec/config_default_spec.rb
@@ -48,7 +48,7 @@ describe ConfigDefault do
 
         expect(config.first).to eq("one")
         expect(config.second).to eq("example")
-        expect { config.third }.to raise_error(StandardError)
+        expect { config.third }.to raise_error(ArgumentError)
       end
     end
 


### PR DESCRIPTION
- Replace `StandardError` with `ArgumentError`.
- Version bump to 0.2.3